### PR TITLE
Use the correct form of `sha512.Sum512`.

### DIFF
--- a/pkg/gate/authenticator.go
+++ b/pkg/gate/authenticator.go
@@ -9,11 +9,12 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"strings"
+	"time"
+
 	"github.com/glide-im/glide/pkg/hash"
 	"github.com/glide-im/glide/pkg/logger"
 	"github.com/glide-im/glide/pkg/messages"
-	"strings"
-	"time"
 )
 
 type CredentialCrypto interface {
@@ -170,9 +171,9 @@ type Authenticator struct {
 }
 
 func NewAuthenticator(gateway DefaultGateway, key string) *Authenticator {
-	k := sha512.New().Sum([]byte(key))
+	k := sha512.Sum512([]byte(key))
 	return &Authenticator{
-		credentialCrypto: NewAesCBCCrypto(k),
+		credentialCrypto: NewAesCBCCrypto(k[:]),
 		gateway:          gateway,
 	}
 }

--- a/pkg/gate/client_test.go
+++ b/pkg/gate/client_test.go
@@ -2,10 +2,11 @@ package gate
 
 import (
 	"crypto/sha512"
-	"github.com/glide-im/glide/pkg/hash"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/glide-im/glide/pkg/hash"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewID(t *testing.T) {
@@ -52,8 +53,8 @@ func TestID_Gateway(t *testing.T) {
 
 func TestAesCBC_Decrypt(t *testing.T) {
 
-	key := sha512.New().Sum([]byte("secret_key"))
-	cbcCrypto := NewAesCBCCrypto(key)
+	key := sha512.Sum512([]byte("secret_key"))
+	cbcCrypto := NewAesCBCCrypto(key[:])
 
 	credentials := ClientAuthCredentials{
 		Type:       1,


### PR DESCRIPTION
`sha512.New().Sum(foo)` appends the SHA-512 hash for nil to foo. See https://go.dev/play/p/vSW0U3Hq4qk (different algorithm but same issue).